### PR TITLE
BatchAutoDiffCost: make shape consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea
+
 # mkdocs documentation
 /site
 

--- a/ilqr/cost.py
+++ b/ilqr/cost.py
@@ -353,7 +353,7 @@ class BatchAutoDiffCost(Cost):
         # Prepare inputs.
         self._x = x = T.dvector("x")
         self._u = u = T.dvector("u")
-        self._i = i = T.dvector("i")
+        self._i = i = T.dscalar("i")
         inputs = [self._x, self._u, self._i]
         inputs_term = [self._x, self._i]
 
@@ -481,9 +481,9 @@ class BatchAutoDiffCost(Cost):
             Instantaneous cost (scalar).
         """
         if terminal:
-            return np.asscalar(self._l_term(x, np.array([i])))
+            return np.asscalar(self._l_term(x, i))
 
-        return np.asscalar(self._l(x, u, np.array([i])))
+        return np.asscalar(self._l(x, u, i))
 
     def l_x(self, x, u, i, terminal=False):
         """Partial derivative of cost function with respect to x.
@@ -498,9 +498,9 @@ class BatchAutoDiffCost(Cost):
             dl/dx [state_size].
         """
         if terminal:
-            return np.array(self._l_x_term(x, np.array([i])))
+            return np.array(self._l_x_term(x, i))
 
-        return np.array(self._l_x(x, u, np.array([i])))
+        return np.array(self._l_x(x, u, i))
 
     def l_u(self, x, u, i, terminal=False):
         """Partial derivative of cost function with respect to u.
@@ -518,7 +518,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros(self._action_size)
 
-        return np.array(self._l_u(x, u, np.array([i])))
+        return np.array(self._l_u(x, u, i))
 
     def l_xx(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to x.
@@ -533,9 +533,9 @@ class BatchAutoDiffCost(Cost):
             d^2l/dx^2 [state_size, state_size].
         """
         if terminal:
-            return np.array(self._l_xx_term(x, np.array([i])))
+            return np.array(self._l_xx_term(x, i))
 
-        return np.array(self._l_xx(x, u, np.array([i])))
+        return np.array(self._l_xx(x, u, i))
 
     def l_ux(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to u and x.
@@ -553,7 +553,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros((self._action_size, self._state_size))
 
-        return np.array(self._l_ux(x, u, np.array([i])))
+        return np.array(self._l_ux(x, u, i))
 
     def l_uu(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to u.
@@ -571,7 +571,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros((self._action_size, self._action_size))
 
-        return np.array(self._l_uu(x, u, np.array([i])))
+        return np.array(self._l_uu(x, u, i))
 
 
 class FiniteDiffCost(Cost):

--- a/ilqr/cost.py
+++ b/ilqr/cost.py
@@ -347,8 +347,8 @@ class BatchAutoDiffCost(Cost):
                 `theano.function()`.
         """
         self._fn = f
-        self._state_size = x_dim = state_size
-        self._action_size = u_dim = action_size
+        self._state_size = state_size
+        self._action_size = action_size
 
         # Prepare inputs.
         self._x = x = T.dvector("x")
@@ -360,14 +360,10 @@ class BatchAutoDiffCost(Cost):
         x_rep_x = T.tile(x, (state_size, 1))
         u_rep_x = T.tile(u, (state_size, 1))
         i_rep_x = T.tile(i, (state_size, 1))
-        inputs_rep_x = [x_rep_x, u_rep_x, i_rep_x]
-        inputs_rep_x_term = [x_rep_x, i_rep_x]
 
         x_rep_u = T.tile(x, (action_size, 1))
         u_rep_u = T.tile(u, (action_size, 1))
         i_rep_u = T.tile(i, (action_size, 1))
-        inputs_rep_u = [x_rep_u, u_rep_u, i_rep_u]
-        inputs_rep_u_term = [x_rep_u, i_rep_u]
 
         x_rep_1 = T.tile(x, (1, 1))
         u_rep_1 = T.tile(u, (1, 1))

--- a/ilqr/cost.py
+++ b/ilqr/cost.py
@@ -416,7 +416,7 @@ class BatchAutoDiffCost(Cost):
 
         # Terminal cost only depends on x, so we only need to evaluate the x
         # partial derivatives.
-        l_tensor_term = f(x, None, i, terminal=True)
+        l_tensor_term = f(x_rep_1, None, i, terminal=True)[0]
         J_x_term, _ = T.grad(
             l_tensor_term, inputs_term, disconnected_inputs="ignore")
 

--- a/ilqr/cost.py
+++ b/ilqr/cost.py
@@ -353,7 +353,7 @@ class BatchAutoDiffCost(Cost):
         # Prepare inputs.
         self._x = x = T.dvector("x")
         self._u = u = T.dvector("u")
-        self._i = i = T.dscalar("i")
+        self._i = i = T.dvector("i")
         inputs = [self._x, self._u, self._i]
         inputs_term = [self._x, self._i]
 
@@ -481,9 +481,9 @@ class BatchAutoDiffCost(Cost):
             Instantaneous cost (scalar).
         """
         if terminal:
-            return np.asscalar(self._l_term(x, i))
+            return np.asscalar(self._l_term(x, np.array([i])))
 
-        return np.asscalar(self._l(x, u, i))
+        return np.asscalar(self._l(x, u, np.array([i])))
 
     def l_x(self, x, u, i, terminal=False):
         """Partial derivative of cost function with respect to x.
@@ -498,9 +498,9 @@ class BatchAutoDiffCost(Cost):
             dl/dx [state_size].
         """
         if terminal:
-            return np.array(self._l_x_term(x, i))
+            return np.array(self._l_x_term(x, np.array([i])))
 
-        return np.array(self._l_x(x, u, i))
+        return np.array(self._l_x(x, u, np.array([i])))
 
     def l_u(self, x, u, i, terminal=False):
         """Partial derivative of cost function with respect to u.
@@ -518,7 +518,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros(self._action_size)
 
-        return np.array(self._l_u(x, u, i))
+        return np.array(self._l_u(x, u, np.array([i])))
 
     def l_xx(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to x.
@@ -533,9 +533,9 @@ class BatchAutoDiffCost(Cost):
             d^2l/dx^2 [state_size, state_size].
         """
         if terminal:
-            return np.array(self._l_xx_term(x, i))
+            return np.array(self._l_xx_term(x, np.array([i])))
 
-        return np.array(self._l_xx(x, u, i))
+        return np.array(self._l_xx(x, u, np.array([i])))
 
     def l_ux(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to u and x.
@@ -553,7 +553,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros((self._action_size, self._state_size))
 
-        return np.array(self._l_ux(x, u, i))
+        return np.array(self._l_ux(x, u, np.array([i])))
 
     def l_uu(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to u.
@@ -571,7 +571,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros((self._action_size, self._action_size))
 
-        return np.array(self._l_uu(x, u, i))
+        return np.array(self._l_uu(x, u, np.array([i])))
 
 
 class FiniteDiffCost(Cost):

--- a/ilqr/cost.py
+++ b/ilqr/cost.py
@@ -353,7 +353,7 @@ class BatchAutoDiffCost(Cost):
         # Prepare inputs.
         self._x = x = T.dvector("x")
         self._u = u = T.dvector("u")
-        self._i = i = T.dvector("i")
+        self._i = i = T.dscalar("i")
         inputs = [self._x, self._u, self._i]
         inputs_term = [self._x, self._i]
 
@@ -369,7 +369,10 @@ class BatchAutoDiffCost(Cost):
         inputs_rep_u = [x_rep_u, u_rep_u, i_rep_u]
         inputs_rep_u_term = [x_rep_u, i_rep_u]
 
-        l_tensor = f(x, u, i, terminal=False)
+        x_rep_1 = T.tile(x, (1, 1))
+        u_rep_1 = T.tile(u, (1, 1))
+        i_rep_1 = T.tile(i, (1, 1))
+        l_tensor = f(x_rep_1, u_rep_1, i_rep_1, terminal=False)[0]
         J_x, J_u = T.grad(l_tensor, [x, u], disconnected_inputs="ignore")
 
         # Compute the hessians in batches.
@@ -495,9 +498,9 @@ class BatchAutoDiffCost(Cost):
             dl/dx [state_size].
         """
         if terminal:
-            return np.array(self._l_x_term(x, np.array([i])))
+            return np.array(self._l_x_term(x, i))
 
-        return np.array(self._l_x(x, u, np.array([i])))
+        return np.array(self._l_x(x, u, i))
 
     def l_u(self, x, u, i, terminal=False):
         """Partial derivative of cost function with respect to u.
@@ -515,7 +518,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros(self._action_size)
 
-        return np.array(self._l_u(x, u, np.array([i])))
+        return np.array(self._l_u(x, u, i))
 
     def l_xx(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to x.
@@ -530,9 +533,9 @@ class BatchAutoDiffCost(Cost):
             d^2l/dx^2 [state_size, state_size].
         """
         if terminal:
-            return np.array(self._l_xx_term(x, np.array([i])))
+            return np.array(self._l_xx_term(x, i))
 
-        return np.array(self._l_xx(x, u, np.array([i])))
+        return np.array(self._l_xx(x, u, i))
 
     def l_ux(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to u and x.
@@ -550,7 +553,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros((self._action_size, self._state_size))
 
-        return np.array(self._l_ux(x, u, np.asarray([i])))
+        return np.array(self._l_ux(x, u, i))
 
     def l_uu(self, x, u, i, terminal=False):
         """Second partial derivative of cost function with respect to u.
@@ -568,7 +571,7 @@ class BatchAutoDiffCost(Cost):
             # Not a function of u, so the derivative is zero.
             return np.zeros((self._action_size, self._action_size))
 
-        return np.array(self._l_uu(x, u, np.array([i])))
+        return np.array(self._l_uu(x, u, i))
 
 
 class FiniteDiffCost(Cost):

--- a/ilqr/dynamics.py
+++ b/ilqr/dynamics.py
@@ -353,20 +353,21 @@ class BatchAutoDiffDynamics(Dynamics):
                 `theano.function()`.
         """
         self._fn = f
-
-        self._x = T.dvector("x")
-        self._u = T.dvector("u")
-        self._i = T.dscalar("i")
-
-        inputs = [self._x, self._u, self._i]
-        self._tensor = f(self._x, self._u, self._i)
-
         self._state_size = state_size
         self._action_size = action_size
 
-        self._J_x, self._J_u, _ = batch_jacobian(f, inputs, state_size)
+        self._x = x = T.dvector("x")
+        self._u = u = T.dvector("u")
+        self._i = i = T.dscalar("i")
+        inputs = [x, u, i]
+
+        x_rep_1 = T.tile(x, (1, 1))
+        u_rep_1 = T.tile(u, (1, 1))
+        i_rep_1 = T.tile(i, (1, 1))
+        self._tensor = f(x_rep_1, u_rep_1, i_rep_1)
         self._f = as_function(self._tensor, inputs, name="f", **kwargs)
 
+        self._J_x, self._J_u, _ = batch_jacobian(f, inputs, state_size)
         self._f_x = as_function(self._J_x, inputs, name="f_x", **kwargs)
         self._f_u = as_function(self._J_u, inputs, name="f_u", **kwargs)
 

--- a/ilqr/dynamics.py
+++ b/ilqr/dynamics.py
@@ -356,7 +356,7 @@ class BatchAutoDiffDynamics(Dynamics):
 
         self._x = T.dvector("x")
         self._u = T.dvector("u")
-        self._i = T.dvector("i")
+        self._i = T.dscalar("i")
 
         inputs = [self._x, self._u, self._i]
         self._tensor = f(self._x, self._u, self._i)
@@ -418,7 +418,7 @@ class BatchAutoDiffDynamics(Dynamics):
         Returns:
             Next state [state_size].
         """
-        return self._f(x, u, np.array([i]))
+        return self._f(x, u, i)
 
     def f_x(self, x, u, i):
         """Partial derivative of dynamics model with respect to x.
@@ -431,7 +431,7 @@ class BatchAutoDiffDynamics(Dynamics):
         Returns:
             df/dx [state_size, state_size].
         """
-        return self._f_x(x, u, np.array([i]))
+        return self._f_x(x, u, i)
 
     def f_u(self, x, u, i):
         """Partial derivative of dynamics model with respect to u.
@@ -444,7 +444,7 @@ class BatchAutoDiffDynamics(Dynamics):
         Returns:
             df/du [state_size, action_size].
         """
-        return self._f_u(x, u, np.array([i]))
+        return self._f_u(x, u, i)
 
     def f_xx(self, x, u, i):
         """Second partial derivative of dynamics model with respect to x.


### PR DESCRIPTION
First of all, thanks for the great repo -- cleanest implementation of iLQR I've found and easily extensible for my needs.

The current implementation of `BatchAutoDiffCost` passes in the inputs without a batch in the first dimension for `l`, `l_x` and `l_u` (i.e. `x.shape == (state_size,)`), and inputs with a batch for `l_xx`, `l_ux` and `l_uu` (i.e. `x.shape == (batch_size, state_size)`). 

Although the cost function `l` can be written to handle both inputs, I find it quite fiddly to get this right, and it means doing things like summing over `axis=-1` since `axis=1` doesn't exist in the non-batch case. In this PR I change the input to always have a batch in the first dimension (sometimes of length 1). I also redefine `i` to be a scalar, which I think it always will be.